### PR TITLE
Refactor DynamicTonemap placebo options

### DIFF
--- a/awsmfunc/base.py
+++ b/awsmfunc/base.py
@@ -1,4 +1,3 @@
-from enum import Enum
 import vapoursynth as vs
 from vapoursynth import core
 
@@ -6,11 +5,14 @@ import math
 from os import PathLike
 from functools import partial
 
+from enum import Enum
 from typing import Callable, Dict, List, Union, Optional, Any
 
 from vsutil import get_depth, split, join, scale_value
 from vsutil import depth as vsuDepth
 from rekt import rektlvls
+
+from .types.placebo import PlaceboTonemapOpts
 
 SUBTITLE_DEFAULT_STYLE: str = ("sans-serif,20,&H00FFFFFF,&H000000FF,&H00000000,&H00000000,"
                                "0,0,0,0,100,100,0,0,1,2,0,7,10,10,10,1")
@@ -980,35 +982,32 @@ def DynamicTonemap(clip: vs.VideoNode,
                    chromaloc_s: str = "left",
                    reference: Optional[vs.VideoNode] = None,
                    predetermined_targets: Optional[Union[str, List[Union[int, float]]]] = None,
-                   is_dovi: bool = False,
                    target_nits: int = 203.0,
                    libplacebo: bool = True,
-                   placebo_dt: bool = True,
-                   placebo_algo: int = None,
-                   placebo_gamut_mode: int = None,
-                   placebo_mode: int = None,
-                   placebo_param: Optional[float] = None,
-                   placebo_use_frame_stats: bool = True) -> vs.VideoNode:
+                   placebo_opts: Optional[PlaceboTonemapOpts] = None) -> vs.VideoNode:
     """
-    The clip (or reference) is blurred, then plane stats are measured.
-    The tonemapping is then done according to the max RGB value.
+    Without libplacebo:
+        The clip (or reference) is blurred, then plane stats are measured.
+        The tonemapping is then done according to the max RGB value.
 
-    :param clip: PQ BT.2020 clip.
-    :param show: Whether to show nits values.
+    :param clip: HDR clip. PQ only if not using libplacebo.
+    :param show: Whether to show nits values as Subtitle.
     :param src_fmt: Whether to output source bit depth instead of 8-bit 4:4:4.
     :param adjust_gamma: Adjusts gamma/saturation dynamically on low brightness areas when target nits are high.
-        Requires adaptivegrain-rs plugin.
+        Requires `adaptivegrain-rs` plugin.
     :param chromaloc_in_s: Chromaloc of input
     :param chromaloc_s: Chromaloc of output
     :param reference: Reference clip to calculate target brightness with.
         Use cases include source/encode comparisons
+        Does not work when using libplacebo with `peak_detect=True`.
     :param predetermined_targets: List of target nits per frame.
         List of numbers or file containing a target per line
-        Must be equal to clip length
+        Must be equal to clip length.
+        Does not work when using libplacebo with `peak_detect=True`.
+    :param target_nits: Target peak white brightness, in nits
     :param libplacebo: Whether to use libplacebo as tonemapper
-        Requires vs-placebo plugin.
-    :param placebo_dt: Use libplacebo's dynamic peak detection instead of FrameEval
-    :param placebo_algo: The tonemapping algo to use
+        Requires `vs-placebo` plugin.
+    :param placebo_opts: See `PlaceboTonemapOpts`, for use with `libplacebo=True`
     :return: SDR YUV444P16 clip by default.
     """
 
@@ -1158,6 +1157,8 @@ def DynamicTonemap(clip: vs.VideoNode,
                 f: vs.VideoFrame,
                 clip: vs.VideoNode,
                 show: bool,
+                placebo_opts: PlaceboTonemapOpts,
+                pl_tm_params: Dict,
                 targets: Optional[List[int]] = None,
                 range: Optional[str] = None) -> vs.VideoNode:
         max_rgb, frame_nits = __calculate_max_rgb(n, f, targets, range=range)
@@ -1169,35 +1170,14 @@ def DynamicTonemap(clip: vs.VideoNode,
 
         if 'MasteringDisplayMinLuminance' in fprops:
             src_min = fprops['MasteringDisplayMinLuminance']
-        else:
-            src_min = 0.0050  # placebo default
 
-        dst_max = target_nits
-        dst_min = dst_max / 1000.0  # 1000:1 default
-
-        can_map_dovi = (is_dovi and 'DolbyVisionRPU' in fprops)
-
-        src_csp = 3 if can_map_dovi else 1
         is_full_range = fprops['_ColorRange'] == 0
 
-        tm_params = {
-            'src_csp': src_csp,
-            'dst_csp': 0,
-            'gamut_mode': placebo_gamut_mode,
-            'tone_mapping_function': placebo_algo,
-            'tone_mapping_param': placebo_param,
-            'tone_mapping_mode': placebo_mode,
-            'dst_max': dst_max,
-            'dst_min': dst_min,
-        }
+        final_tm_params = pl_tm_params
+        if placebo_opts.use_planestats:
+            final_tm_params = {'src_max': src_max, 'src_min': src_min, **pl_tm_params}
 
-        if placebo_use_frame_stats:
-            tm_params.update({
-                'src_max': src_max,
-                'src_min': src_min,
-            })
-
-        clip = core.placebo.Tonemap(clip, dynamic_peak_detection=False, **tm_params)
+        clip = core.placebo.Tonemap(clip, **final_tm_params)
 
         if show and clip.format.color_family != vs.YUV:
             show_clip = core.resize.Spline36(clip, format=vs.YUV444P16, matrix_s="709")
@@ -1237,32 +1217,38 @@ def DynamicTonemap(clip: vs.VideoNode,
     use_placebo = libplacebo and HasLoadedPlugin("com.vs.placebo")
 
     if use_placebo:
-        dst_fmt = vs.YUV444P16 if is_dovi else vs.RGB48
+        placebo_opts_final = placebo_opts
+        if not placebo_opts_final:
+            placebo_opts_final = PlaceboTonemapOpts()
+
+        dst_fmt = vs.YUV444P16 if placebo_opts_final.is_dovi_src() else vs.RGB48
 
         clip = core.resize.Spline36(clip, format=dst_fmt, chromaloc_in_s=chromaloc_in_s, chromaloc_s=chromaloc_in_s)
 
-        if placebo_dt:
-            dst_max = target_nits
+        dst_max = target_nits
+        dst_min = None
+
+        if placebo_opts_final.is_sdr_target():
             dst_min = dst_max / 1000.0  # 1000:1 default
 
-            tm_params = {
-                'src_csp': 3 if is_dovi else 1,
-                'dst_csp': 0,
-                'gamut_mode': placebo_gamut_mode,
-                'tone_mapping_function': placebo_algo,
-                'tone_mapping_param': placebo_param,
-                'tone_mapping_mode': placebo_mode,
-                'dst_max': dst_max,
-                'dst_min': dst_min,
-            }
+        pl_tm_params = {'dst_max': dst_max, 'dst_min': dst_min, **placebo_opts_final.vsplacebo_dict()}
 
+        if placebo_opts_final.peak_detect:
             # Tonemap
-            tonemapped_clip = core.placebo.Tonemap(clip, dynamic_peak_detection=True, **tm_params)
+            tonemapped_clip = core.placebo.Tonemap(clip, **pl_tm_params)
         else:
+            if not placebo_opts_final.is_hdr10_src():
+                raise ValueError('Dynamic tonemapping using PlaneStats only supports HDR10 input clips')
+
             prop_src = __get_rgb_prop_src(clip, reference, target_list)
 
             tonemapped_clip = core.std.FrameEval(clip,
-                                                 partial(__pl_dt, clip=clip, targets=target_list, show=show),
+                                                 partial(__pl_dt,
+                                                         clip=clip,
+                                                         placebo_opts=placebo_opts_final,
+                                                         pl_tm_params=pl_tm_params,
+                                                         targets=target_list,
+                                                         show=show),
                                                  prop_src=prop_src)
 
         if tonemapped_clip.format.color_family == vs.YUV:

--- a/awsmfunc/types/placebo.py
+++ b/awsmfunc/types/placebo.py
@@ -1,0 +1,117 @@
+from enum import IntEnum
+from typing import Dict, NamedTuple, Optional
+
+
+class PlaceboColorSpace(IntEnum):
+    SDR = 0
+    HDR10 = 1
+    HLG = 2
+    DOVI = 3
+    """Process profile 5/7/8 Dolby Vision"""
+
+
+class PlaceboTonemapFunction(IntEnum):
+    Auto = 0
+    Clip = 1
+    BT2390 = 2
+    BT2446a = 3
+    Spline = 4
+    Reinhard = 5
+    Mobius = 6
+    Hable = 7
+    Gamma = 8
+    Linear = 9
+
+
+class PlaceboGamutMode(IntEnum):
+    Clip = 0
+    Warn = 1
+    Darken = 2
+    Desaturate = 3
+
+
+class PlaceboTonemapMode(IntEnum):
+    Auto = 0
+    RGB = 1
+    Max = 2
+    Hybrid = 3
+    Luma = 4
+
+
+class PlaceboTonemapOpts(NamedTuple):
+    """Options for vs-placebo Tonemap. For use with awsmfunc.DynamicTonemap.
+
+    Attributes:
+        `source_colorspace`: Input clip colorpsace. Defaults to HDR10 (PQ + BT.2020)
+        `target_colorspace`: Output clip colorpsace. Defaults to SDR (BT.1886 + BT.709)
+        `peak_detect`: Use libplacebo's dynamic peak detection instead of FrameEval
+        `gamut_mode`: How to handle out-of-gamut colors when changing the content primaries
+        `tone_map_function`: Tone map function to use for luma
+        `tone_map_param`: Parameter for the tone map function
+        `tone_map_mode`: Tone map mode to map colours/chroma
+        `tone_map_crosstalk`: Extra crosstalk factor to apply before tone mapping
+        `use_dovi`: Whether to use the Dolby Vision RPU for ST2086 metadata
+            This does not do extra processing, only uses the RPU for extra metadata
+        `smoothing_period`, `scene_threshold_low`, `scene_threshold_high`: Peak detection parameters
+        `use_planestats`: When peak detection is disabled, whether to use the frame max RGB for tone mapping
+    """
+
+    source_colorspace: PlaceboColorSpace = PlaceboColorSpace.HDR10
+    """Input clip colorpsace. Defaults to HDR10 (PQ + BT.2020)"""
+    target_colorspace: PlaceboColorSpace = PlaceboColorSpace.SDR
+    """Output clip colorpsace. Defaults to SDR (BT.1886 + BT.709)"""
+
+    peak_detect: bool = True
+    """Use libplacebo's dynamic peak detection instead of FrameEval"""
+    gamut_mode: Optional[PlaceboGamutMode] = None
+    """How to handle out-of-gamut colors when changing the content primaries"""
+    tone_map_function: Optional[PlaceboTonemapFunction] = None
+    """Tone map function to use for luma"""
+    tone_map_param: Optional[float] = None
+    """Parameter for the tone map function"""
+    tone_map_mode: Optional[PlaceboTonemapMode] = None
+    """Tone map mode to map colours/chroma"""
+    tone_map_crosstalk: Optional[float] = None
+    """Extra crosstalk factor to apply before tone mapping"""
+    use_dovi: Optional[bool] = None
+    """Whether to use the Dolby Vision RPU for ST2086 metadata
+
+        This does not do extra processing, only uses the RPU for extra metadata
+    """
+
+    smoothing_period: Optional[float] = None
+    scene_threshold_low: Optional[float] = None
+    scene_threshold_high: Optional[float] = None
+
+    use_planestats: bool = True
+    """When peak detection is disabled, whether to use the frame max RGB for tone mapping"""
+
+    def with_static_peak_detect(self):
+        """Ignore peak detect smoothing and scene detection"""
+        return self._replace(smoothing_period=-1, scene_threshold_low=-1, scene_threshold_high=-1)
+
+    def vsplacebo_dict(self) -> Dict:
+        return {
+            'src_csp': self.source_colorspace,
+            'dst_csp': self.target_colorspace,
+            'dynamic_peak_detection': self.peak_detect,
+            'gamut_mode': self.gamut_mode,
+            'tone_mapping_function': self.tone_map_function,
+            'tone_mapping_param': self.tone_map_param,
+            'tone_mapping_mode': self.tone_map_mode,
+            'tone_mapping_crosstalk': self.tone_map_crosstalk,
+            'use_dovi': self.use_dovi,
+            'smoothing_period': self.smoothing_period,
+            'scene_threshold_low': self.scene_threshold_low,
+            'scene_threshold_high': self.scene_threshold_high,
+        }
+
+    def is_dovi_src(self) -> bool:
+        """Whether the options process the clip as Dolby Vision"""
+        return self.source_colorspace == PlaceboColorSpace.DOVI
+
+    def is_hdr10_src(self) -> bool:
+        return self.source_colorspace == PlaceboColorSpace.HDR10
+
+    def is_sdr_target(self) -> bool:
+        return self.target_colorspace == PlaceboColorSpace.SDR

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ setup(
     url='https://github.com/OpusGang/awsmfunc',
     license='MIT',
     author='OpusGang',
-    packages=['awsmfunc'],
+    packages=['awsmfunc', 'awsmfunc.types'],
     package_data={
         'awsmfunc': ['py.typed'],
     },


### PR DESCRIPTION
Example usage:
```python3
import awsmfunc as awf
from awsmfunc.types import placebo

pl_opts = placebo.PlaceboTonemapOpts(
    peak_detect=True,
    gamut_mode=placebo.PlaceboGamutMode.Clip,
    tone_map_function=placebo.PlaceboTonemapFunction.BT2390,
    tone_map_param=2.0,
    tone_map_mode=placebo.PlaceboTonemapMode.Hybrid
)

clip = awf.DynamicTonemap(clip, libplacebo=True, placebo_opts=pl_opts)
```