### PR TITLE
Fix plane count check in bandmask (had always passed).

### DIFF
--- a/awsmfunc/detect.py
+++ b/awsmfunc/detect.py
@@ -87,7 +87,7 @@ def bandmask(clip: vs.VideoNode,
     :param blankthr: If set, values with less change than this will be ignored and set black.
     :return: Grayscale mask of areas with gradient smaller than thr.
     """
-    if len([plane]) != 1:
+    if len(tuple(plane)) != 1:
         raise ValueError("bandmask: Only one plane can be processed at once!")
 
     depth = clip.format.bits_per_sample


### PR DESCRIPTION
This test was always passing because it was creating a single-element list every time. I'm assuming the intention was to finalize an iterable if one was used instead of a sequence, so I maintained the conversion.